### PR TITLE
feat: Support no read-replication for Memorystore [DEVOP-4801]

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -1,4 +1,5 @@
 name: "Checkov GitHub Action"
+permissions: read-all
 on:
   pull_request:
     branches: [test, dev, qa, prod, main]

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,5 +1,7 @@
 name: "Semantic Pull Request"
-
+permissions:
+  contents: write
+  pull-requests: write
 on:
   pull_request:
     types:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,4 +1,5 @@
 name: "terraform"
+permissions: read-all
 on:
   pull_request:
     branches:

--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -1,4 +1,7 @@
 name: terratest
+permissions:
+  contents: write
+  pull-requests: write
 on:
   pull_request:
     branches:

--- a/examples/create_redis_public_ip/README.md
+++ b/examples/create_redis_public_ip/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/examples/create_redis_public_ip/main.tf
+++ b/examples/create_redis_public_ip/main.tf
@@ -13,11 +13,14 @@ resource "random_id" "instance_suffix" {
 }
 
 module "private_network" {
+  #checkov:skip=CKV_TF_1:We use the version tag instead of the commit hash
+  #checkov:skip=CKV2_GCP_18:We ignore the creation of firewall rules
   source = "git::https://github.com/honestbank/terraform-gcp-sql.git//modules/google_compute_network?ref=v1.1.1"
   name   = "test-redis-terraform-${random_id.instance_suffix.hex}"
 }
 
 module "google_compute_global_address_private_ip_address" {
+  #checkov:skip=CKV_TF_1:We use the version tag instead of the commit hash
   source = "git::https://github.com/honestbank/terraform-gcp-sql.git//modules/google_compute_global_address?ref=v1.1.1"
 
   name          = "redis-pip-${random_id.instance_suffix.hex}"
@@ -28,6 +31,7 @@ module "google_compute_global_address_private_ip_address" {
 }
 
 module "google_service_networking_connection_private_vpc_connection" {
+  #checkov:skip=CKV_TF_1:We use the version tag instead of the commit hash
   source = "git::https://github.com/honestbank/terraform-gcp-sql.git//modules/google_service_networking_connection?ref=v1.1.1"
 
   network                 = module.private_network.id

--- a/modules/memstore_redis/README.md
+++ b/modules/memstore_redis/README.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.29.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.38.0 |
 
 ## Modules
 
@@ -33,7 +33,7 @@ No modules.
 | <a name="input_read_replicas_enabled"></a> [read\_replicas\_enabled](#input\_read\_replicas\_enabled) | Whether to enable read replicas | `bool` | `false` | no |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The version of Redis to use | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to create the instance in | `string` | `"asia-southeast2"` | no |
-| <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of instances to create | `number` | `1` | no |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of read replicas to create | `number` | `0` | no |
 | <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | The reserved IP range to use for the instance | `string` | `null` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | The tier of the instance | `string` | n/a | yes |
 | <a name="input_zone"></a> [zone](#input\_zone) | The location to create the instance in | `string` | n/a | yes |

--- a/modules/memstore_redis/variables.tf
+++ b/modules/memstore_redis/variables.tf
@@ -40,7 +40,6 @@ variable "reserved_ip_range" {
   description = "The reserved IP range to use for the instance"
 }
 
-
 variable "memory_size" {
   type        = string
   default     = "2"
@@ -49,11 +48,11 @@ variable "memory_size" {
 
 variable "replicas" {
   type        = number
-  default     = 1
-  description = "The number of instances to create"
+  default     = 0
+  description = "The number of read replicas to create"
   validation {
-    condition     = var.replicas >= 1 && var.replicas <= 5
-    error_message = "The valid range for the Standard Tier with read replicas enabled is [1-5] and defaults to 1."
+    condition     = var.replicas <= 5
+    error_message = "The valid range for the Standard Tier with read replicas enabled is [1-5] and defaults to 0 as the default is zero read-replicas."
   }
 }
 


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

In order to right-size the current Memorystore instances, we need to not
enforce read-replica contraints as at minimum you require 5GB in order
to enable a read-replica, yet current production instances are utilising
less than 1GB.

Refs: #DEVOP-4801

Signed-off-by: Christian Witts <christian@honestbank.com>

<!-- WRITE A SHORT DESCRIPTION OF CHANGES -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-memstore/18)
<!-- Reviewable:end -->
