### PR TITLE
feat: change the precondition in the gcp memstore module [devop-6442] 

### DIFF
--- a/modules/memstore_redis/main.tf
+++ b/modules/memstore_redis/main.tf
@@ -40,8 +40,14 @@ resource "google_redis_instance" "cache" {
       error_message = "Read replicas are not supported on the BASIC tier."
     }
     precondition {
-      condition     = (var.read_replicas_enabled && var.replicas > 0) || (var.replicas == 0 && var.read_replicas_enabled == false)
-      error_message = "You require at least 1 read replica if read replicas are enabled."
+      condition = (
+        (var.read_replicas_enabled && var.replicas > 0)
+        || (!var.read_replicas_enabled && (
+          (var.tier == "STANDARD_HA" && var.replicas == 1)
+          || (var.tier == "BASIC" && var.replicas == 0)
+        ))
+      )
+      error_message = "Invalid replica configuration: If read replicas are enabled, at least 1 replica is required. If read replicas are disabled, replicas must be 0 for BASIC tier or 1 for STANDARD_HA."
     }
   }
 }


### PR DESCRIPTION
### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [x] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description
This PR updates the lifecycle precondition logic for the google_redis_instance resource to align with the Memorystore API’s supported configuration, allowing:
* replica_count = 1
* tier = "STANDARD_HA"
* read_replicas_enabled = false

<img width="857" alt="image" src="https://github.com/user-attachments/assets/b5f665e8-275a-427f-85c9-8a8c421ea916" />


https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.replica_count
