### PR TITLE
feat: support defining maintenance window [MLOPS-8056]

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.21'
         id: go
       - name: Run 'go test -v -timeout 60m'
         run: |

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
         id: go
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -23,6 +23,10 @@ jobs:
         with:
           go-version: '1.21'
         id: go
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       - name: Run 'go test -v -timeout 60m'
         run: |
           cd test

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -9,6 +9,8 @@ env:
   AWS_SECRET_KEY: ${{ secrets.TERRATEST_AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ secrets.TERRATEST_AWS_REGION }}
   AWS_REGION: ${{ secrets.TERRATEST_AWS_REGION }}
+  TF_VAR_google_project: ${{ secrets.TERRATEST_GOOGLE_PROJECT }}
+  TF_VAR_google_credentials: ${{ secrets.TERRATEST_GOOGLE_CREDENTIALS }}
 jobs:
   terratest:
     name: terratest

--- a/modules/memstore_redis/main.tf
+++ b/modules/memstore_redis/main.tf
@@ -30,6 +30,21 @@ resource "google_redis_instance" "cache" {
   display_name      = var.name
   reserved_ip_range = var.reserved_ip_range != null ? var.reserved_ip_range : null
 
+  dynamic "maintenance_policy" {
+    for_each = var.maintenance == null ? [] : [var.maintenance]
+    content {
+      weekly_maintenance_window {
+        day = upper(maintenance_policy.value.day)
+        start_time {
+          hours   = maintenance_policy.value.hours
+          minutes = maintenance_policy.value.minutes
+          seconds = 0
+          nanos   = 0
+        }
+      }
+    }
+  }
+
   lifecycle {
     precondition {
       condition     = (var.read_replicas_enabled && var.memory_size >= 5) || var.read_replicas_enabled == false

--- a/modules/memstore_redis/variables.tf
+++ b/modules/memstore_redis/variables.tf
@@ -72,3 +72,22 @@ variable "encryption" {
   default     = true
   description = "Whether to enable encryption"
 }
+
+variable "maintenance" {
+  description = "Optional weekly maintenance window (UTC). Omit to let GCP choose."
+  type = object({
+    day     = string # e.g., "MONDAY"
+    hours   = number # 0..23
+    minutes = number # 0..59
+  })
+  default = null
+
+  validation {
+    condition = var.maintenance == null || (
+      contains(["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"], upper(var.maintenance.day)) &&
+      var.maintenance.hours >= 0 && var.maintenance.hours <= 23 &&
+      var.maintenance.minutes >= 0 && var.maintenance.minutes <= 59
+    )
+    error_message = "maintenance: day must be MONDAY..SUNDAY; time must be a valid UTC time."
+  }
+}


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [ ] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description

* Support defining Memorystore weekly maintenance window so that we can target low traffic office hours.
* Fix Terratest CI pipeline:
  * Wrap Go version:
    > The recommendation is based on the YAML parser's behavior, which interprets non-wrapped values as numbers and, in the case of version 1.20, trims it down to 1.2, which may not be very obvious.
  * Update Go version:
    ```
    Run cd test
    # github.com/honestbank/terraform-gcp-memstore
    FAIL	github.com/honestbank/terraform-gcp-memstore [setup failed]
    Error: ../../../../go/pkg/mod/github.com/aws/smithy-go@v1.22.1/properties.go:3:8: package maps is not in GOROOT (/opt/hostedtoolcache/go/1.20.14/x64/src/maps)
    note: imported by a module that requires go 1.21
    Error: Process completed with exit code 1.
    ```
  * Install TF (fails otherwise)
  * Add required TF variables

