### PR TITLE
feat: adding the secondary ip range variable for the read replica [MLOPS-8152]

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,4 +1,5 @@
 name: "Terraform GitHub Action"
+permissions: read-all
 on:
   pull_request:
     # This workflow is meant for public Terraform module repositories

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -1,4 +1,5 @@
 name: "Terratest GitHub Action"
+permissions: read-all
 on:
   pull_request:
     branches: [test, dev, qa, prod, main]

--- a/modules/memstore_redis/main.tf
+++ b/modules/memstore_redis/main.tf
@@ -29,6 +29,7 @@ resource "google_redis_instance" "cache" {
   redis_version     = var.redis_version
   display_name      = var.name
   reserved_ip_range = var.reserved_ip_range != null ? var.reserved_ip_range : null
+  secondary_ip_range = var.secondary_ip_range != null ? var.secondary_ip_range : null
 
   dynamic "maintenance_policy" {
     for_each = var.maintenance == null ? [] : [var.maintenance]

--- a/modules/memstore_redis/variables.tf
+++ b/modules/memstore_redis/variables.tf
@@ -40,6 +40,12 @@ variable "reserved_ip_range" {
   description = "The reserved IP range to use for the instance"
 }
 
+variable "secondary_ip_range" {
+  type        = string
+  default     = null
+  description = "The secondary IP range to use for the instance"
+}
+
 variable "memory_size" {
   type        = string
   default     = "2"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [x] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description

Adding the "secondary_ip_range" variable in the module in order to support read replicas refer to this: https://registry.terraform.io/modules/terraform-google-modules/memorystore/google/latest?tab=inputs
