### PR TITLE
feat: [DEVOP-7633] upgrade Go to 1.26 in terratest modules

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: 1.26
         id: go
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/honestbank/terraform-gcp-memstore
 
-go 1.21
+go 1.26
 
 require (
 	github.com/gruntwork-io/terratest v0.48.2


### PR DESCRIPTION
## Summary
- Upgraded Go version to 1.26 in all terratest go.mod files
- Ran `go mod tidy` to update dependencies
- Updated GitHub Actions workflow `.github/workflows/terratest.yaml` go-version to 1.26

## go.mod files updated
- `test/go.mod`


## Linear Issue
DEVOP-7633